### PR TITLE
Update AUTHORS, CHANGELOG.md for null_safety update

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 
 Boris Kaul <localvoid@gmail.com>
 Kwang Yul Seo <kwangyul.seo@gmail.com>
+Philip Sieder <philip.sieder@gmx.de>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
    * Upgrade to sound null safety
    * Require Dart 2.12.0-0
 
-## 1.0.4-dev
-   * Require Dart 2.2.0.
-
 ## 1.0.3
    * Require Dart 2.0.0.
    * Fixed Tuple7's operator==.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+   * Upgrade to sound null safety
+   * Require Dart 2.12.0-0
+
 ## 1.0.4-dev
    * Require Dart 2.2.0.
 


### PR DESCRIPTION
As discussed in https://github.com/google/tuple.dart/pull/24 the missing update to the Changelog.

Going once again through all files: Added me to the `AUTHORS` file 